### PR TITLE
Implement background click support

### DIFF
--- a/motion.cpp
+++ b/motion.cpp
@@ -46,6 +46,25 @@ void left_click(HWND hwnd, int pos_x, int pos_y)
     }
 }
 
+void left_click_background(HWND hwnd, int pos_x, int pos_y)
+{
+    if (!IsWindow(hwnd))
+    {
+        qWarning() << "left_click_background: invalid window";
+        return;
+    }
+    if (IsIconic(hwnd))
+    {
+        qWarning() << "left_click_background: window is minimized";
+        return;
+    }
+
+    LPARAM lParam = MAKELPARAM(pos_x, pos_y);
+    PostMessage(hwnd, WM_MOUSEMOVE, 0, lParam);
+    PostMessage(hwnd, WM_LBUTTONDOWN, MK_LBUTTON, lParam);
+    PostMessage(hwnd, WM_LBUTTONUP, 0, lParam);
+}
+
 void click_center_and_keyL(HWND aim_hwnd)
 {
     RECT r;
@@ -234,4 +253,13 @@ void click_center(HWND aim_hwnd)
     int cy = (r.top  + r.bottom) / 2;
     // 点击
     left_click(aim_hwnd, cx, cy);
+}
+
+void click_center_background(HWND aim_hwnd)
+{
+    RECT r;
+    ::GetWindowRect(aim_hwnd, &r);
+    int cx = (r.left + r.right) / 2;
+    int cy = (r.top  + r.bottom) / 2;
+    left_click_background(aim_hwnd, cx, cy);
 }

--- a/motion.h
+++ b/motion.h
@@ -10,7 +10,13 @@ void click_center_and_ESC(HWND aim_hwnd);
 
 void click_center(HWND aim_hwnd);
 
+void click_center_background(HWND aim_hwnd);
+
 void left_click(HWND hwnd, int pos_x, int pos_y);
+
+// Click without forcing the window to foreground. Window must be visible
+// but can stay in background.
+void left_click_background(HWND hwnd, int pos_x, int pos_y);
 
 void paste_text(const QString &message);
 


### PR DESCRIPTION
## Summary
- introduce `left_click_background` and `click_center_background` to allow
  sending click messages without bringing the window to the foreground
- add declarations for the new helpers

## Testing
- `g++ -c motion.cpp` *(fails: `windows.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688725a95ee483239ca77f81dabc70a7